### PR TITLE
libjson0-dev needed on Ubuntu 12.04 in order to allow ./configure to succeed

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ BUILDING:
     packages) installed to build it.  From a base Debian or Ubuntu install,
     this should get you to a point you can build and run it:
         apt-get install build-essential libcurl4-openssl-dev libxml2-dev \
-             libssl-dev libfuse-dev
+             libssl-dev libfuse-dev libjson0-dev
 
     For CentOS or similar,
         yum install gcc make fuse-devel curl-devel libxml2-devel openssl-devel


### PR DESCRIPTION
Adding libjson0-dev in the list of dependancies to allow ./configure to work properly.
