### PR TITLE
Fix building with json-c lib name (Issue #15).

### DIFF
--- a/cloudfsapi.c
+++ b/cloudfsapi.c
@@ -15,7 +15,7 @@
 #include <libxml/tree.h>
 #include <openssl/bio.h>
 #include <openssl/evp.h>
-#include <json/json.h>
+#include <json.h>
 #include "cloudfsapi.h"
 #include "config.h"
 

--- a/configure.ac
+++ b/configure.ac
@@ -14,14 +14,14 @@ AC_PROG_INSTALL
 AC_PROG_MKDIR_P
 
 # Checks that pkg-config is installed
-
 PKG_PROG_PKG_CONFIG
 
 # Checks for libraries.
 PKG_CHECK_MODULES(XML, libxml-2.0, , AC_MSG_ERROR('Unable to find libxml2. Please make sure library and header files are installed.'))
 PKG_CHECK_MODULES(CURL, libcurl, , AC_MSG_ERROR('Unable to find libcurl.  Please make sure library and header files are installed.'))
 PKG_CHECK_MODULES(FUSE, fuse, , AC_MSG_ERROR('Unable to find libfuse.  Please make sure library and header files are installed.'))
-PKG_CHECK_MODULES(JSON, json, , AC_MSG_ERROR('Unable to find libjson.  Please make sure library and header files are installed.'))
+PKG_CHECK_MODULES(JSON, json-c, ,
+	PKG_CHECK_MODULES(JSON, json, , AC_MSG_ERROR('Unable to find libjson.  Please make sure library and header files are installed.')))
 PKG_CHECK_MODULES(OPENSSL, openssl, , [])
 
 # Checks for header files.


### PR DESCRIPTION
I think this should fix configure (after regen) and make for the json-c lib name. In debian/ubuntu there is a transitional package - libjson0-dev - that supplies package config using the 'json' name, but not everybody would know to install that and other distros may not have an equivalent (e.g. issue #15).
