### PR TITLE
Honour LDFLAGS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -26,7 +26,7 @@ $(bindir):
 	$(MKDIR_P) $(bindir)
 
 hubicfuse: $(SOURCES) $(HEADERS)
-	$(CC) $(CFLAGS) -o hubicfuse $(SOURCES) $(LIBS)
+	$(CC) $(CFLAGS) -o hubicfuse $(SOURCES) $(LIBS) $(LDFLAGS)
 
 clean:
 	/bin/rm -f hubicfuse


### PR DESCRIPTION
Thanks for hubicfuse! I've [added](https://github.com/Entware/rtndev/commit/4d8be5162d35efe1f429346cb42723c44d01186e) it to my repo for MIPSEL routers. Works quite fast:
```
admin@RT-N66U:/tmp/mnt/OPT/tmp# /opt/bin/dd if=/dev/zero of=/mnt/hubic/default/nonsense.swp bs=1M count=20
20+0 records in
20+0 records out
20971520 bytes (21 MB) copied, 2.95041 s, 7.1 MB/s

admin@RT-N66U:/tmp/home/root# top -n 1 | tail
17202 admin     15   0 12308 2960 1972 S 29.1  1.2   0:01.93 hubicfuse
17213 admin     15   0  1496  632  468 R  1.0  0.3   0:00.10 top
    2 admin     10  -5     0    0    0 S  0.0  0.0   0:00.00 kthreadd
    3 admin     36  19     0    0    0 S  0.0  0.0   0:09.03 ksoftirqd/0
    1 admin     18   0  4504 1416 1184 S  0.0  0.6   0:43.48 init
   20 admin     10  -5     0    0    0 S  0.0  0.0   0:00.00 kblockd/0
   51 admin     24   0     0    0    0 S  0.0  0.0   0:00.00 pdflush
    4 admin     10  -5     0    0    0 S  0.0  0.0   0:02.04 events/0
    5 admin     10  -5     0    0    0 S  0.0  0.0   0:00.01 khelper
   54 admin     19  -5     0    0    0 S  0.0  0.0   0:00.00 aio/0
```
