### PR TITLE
hubic_token Busybox compatibility

### DIFF
--- a/hubic_token
+++ b/hubic_token
@@ -139,8 +139,8 @@
 # --------------------------------------------------------------------------------------
 # Internal constants                                                                   |
 # --------------------------------------------------------------------------------------
-readonly URL_AUTH='https://api.hubic.com/oauth'
-readonly VERSION='1.0.0'
+URL_AUTH='https://api.hubic.com/oauth'
+VERSION='1.0.0'
 RANDOM_STR='TVq6zsU0A_GHIS6iYtbc7uc2c5jdpwIMczyMCsABJXbd'
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
Many small devices (like routers) are using `busybox` instead of full-blown `coreutils`. This pull-request fixes `readonly error` when running under `busybox`.

You may ignore\close this if it's out of project goal. Thanks for the patience.