### PR TITLE
Fix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -12,7 +12,7 @@ exec_prefix = @exec_prefix@
 bindir = $(DESTDIR)$(exec_prefix)/bin
 
 SOURCES=cloudfsapi.c cloudfuse.c
-HEADERS=cloudfsapi.h
+HEADERS=cloudfsapi.h cloudfuse.h
 
 all: hubicfuse
 

--- a/cloudfsapi.c
+++ b/cloudfsapi.c
@@ -429,7 +429,8 @@ int format_segments(const char *path, char * seg_base,  int *segments,
     if (!cloudfs_list_directory(seg_path, &seg_dir))
       return 0;
 
-    long total_size = strtoll(str_size, NULL, 10);
+    //use off_t for large files download under x86
+    off_t total_size = strtoll(str_size, NULL, 10);
     *size_of_segments = strtoll(str_segment, NULL, 10);
 
     *remaining = total_size % *size_of_segments;
@@ -572,7 +573,7 @@ int cloudfs_object_read_fp(const char *path, FILE *fp)
 
     // reusing manifest
     snprintf(manifest, MAX_URL_SIZE, "%s_segments/%s/%s/%lld/%lld/",
-        container, object, meta_mtime, flen, segment_size);
+        container, object, meta_mtime, (long long int)flen, (long long int)segment_size);
 
     char tmp[MAX_URL_SIZE];
     strncpy(tmp, seg_base, MAX_URL_SIZE);

--- a/cloudfsapi.h
+++ b/cloudfsapi.h
@@ -1,8 +1,50 @@
 #ifndef _CLOUDFSAPI_H
 #define _CLOUDFSAPI_H
+#define _GNU_SOURCE
+#define _FILE_OFFSET_BITS  64
+#include <stdio.h>
+#include <assert.h>
+#include <magic.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#ifdef __linux__
+#include <alloca.h>
+#endif
+#include <pthread.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <libxml/tree.h>
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <json.h>
+#include <libxml/xpath.h>
+#include <libxml/xpathInternals.h>
+#include "config.h"
+#include <fuse.h>
+#include <errno.h>
 
 #include <curl/curl.h>
 #include <curl/easy.h>
+
+#define RHEL5_LIBCURL_VERSION 462597
+#define RHEL5_CERTIFICATE_FILE "/etc/pki/tls/certs/ca-bundle.crt"
+
+#define REQUEST_RETRIES 4
+
+#define MAX_FILES 10000
+
+// 64 bit time + nanoseconds
+#define TIME_CHARS 32
+
+// size of buffer for writing to disk look at ioblksize.h in coreutils
+// and try some values on your own system if you want the best performance
+#define DISK_BUFF_SIZE 32768
+
 
 #define BUFFER_INITIAL_SIZE 4096
 #define MAX_HEADER_SIZE 8192
@@ -46,14 +88,14 @@ struct segment_info
 {
     FILE *fp;
     int part;
-    long size;
-    long segment_size;
+    off_t size;
+    off_t segment_size;
     char *seg_base;
     const char *method;
 };
 
-long segment_size;
-long segment_above;
+off_t segment_size;
+off_t segment_above;
 
 char *override_storage_url;
 char *public_container;
@@ -73,6 +115,7 @@ off_t cloudfs_file_size(int fd);
 void cloudfs_debug(int dbg);
 void cloudfs_verify_ssl(int dbg);
 void cloudfs_free_dir_list(dir_entry *dir_list);
+int cloudfs_statfs(const char *path, struct statvfs *stat);
 
 void debugf(char *fmt, ...);
 #endif

--- a/cloudfsapi.h
+++ b/cloudfsapi.h
@@ -1,9 +1,7 @@
 #ifndef _CLOUDFSAPI_H
 #define _CLOUDFSAPI_H
 #define _GNU_SOURCE
-#define _FILE_OFFSET_BITS  64
 #include <stdio.h>
-#include <assert.h>
 #include <magic.h>
 #include <string.h>
 #include <stdarg.h>
@@ -92,6 +90,7 @@ struct segment_info
     off_t segment_size;
     char *seg_base;
     const char *method;
+    int success;
 };
 
 off_t segment_size;
@@ -116,6 +115,7 @@ void cloudfs_debug(int dbg);
 void cloudfs_verify_ssl(int dbg);
 void cloudfs_free_dir_list(dir_entry *dir_list);
 int cloudfs_statfs(const char *path, struct statvfs *stat);
+int run_segment_threads(const char *method, int segments, int full_segments, off_t remaining, FILE *fp, char *seg_base, off_t size_of_segments);
 
 void debugf(char *fmt, ...);
 #endif

--- a/cloudfuse.c
+++ b/cloudfuse.c
@@ -640,8 +640,8 @@ int main(int argc, char **argv)
     fprintf(stderr, "The following settings are optional:\n\n");
     fprintf(stderr, "  cache_timeout=[Seconds for directory caching, default %ss]\n", CACHE_TIMEOUT);
     fprintf(stderr, "  verify_ssl=[False to disable SSL cert verification, default %s]\n", VERIFY_SSL);
-    fprintf(stderr, "  segment_size=[Size to use when creating DLOs, default %s kb]\n", SEGMENT_SIZE);
-    fprintf(stderr, "  segment_above=[File size at which to use segments, default %s kb]\n", SEGMENT_ABOVE);
+    fprintf(stderr, "  segment_size=[Size to use when creating DLOs, default %s b]\n", SEGMENT_SIZE);
+    fprintf(stderr, "  segment_above=[File size at which to use segments, default %s b]\n", SEGMENT_ABOVE);
     fprintf(stderr, "  storage_url=[Storage URL for other tenant to view container]\n");
     fprintf(stderr, "  container=[Public container to view of tenant specified by storage_url]\n");
     fprintf(stderr, "  temp_dir=[Directory to store temp files]\n");

--- a/cloudfuse.h
+++ b/cloudfuse.h
@@ -1,0 +1,11 @@
+#define FUSE_USE_VERSION 26
+#define _FILE_OFFSET_BITS  64
+#include <pwd.h>
+#include <signal.h>
+#include "cloudfsapi.h"
+
+#define CACHE_TIMEOUT "600"
+#define VERIFY_SSL "true"
+#define SEGMENT_SIZE "1073741824"
+#define MIN_SEGMENT_SIZE 10485760 /* is 10 times less than SEGMENT_SIZE fine ?*/
+#define SEGMENT_ABOVE "2147483647"

--- a/cloudfuse.h
+++ b/cloudfuse.h
@@ -1,5 +1,4 @@
 #define FUSE_USE_VERSION 26
-#define _FILE_OFFSET_BITS  64
 #include <pwd.h>
 #include <signal.h>
 #include "cloudfsapi.h"


### PR DESCRIPTION
- Issue 32 : FPE fix (only on x86 ?).
- Fix upload and download for files > 2GB on x86.
  - at upload, replaced ftell by ftello. (beginning of cloudfs_object_read_fp; now calling cloudfs_file_size)
  - at download, replaced fseek by fseeko in upload_segment.
  - in both cases, because files, segments, remaining lengths stored as long int aren't sufficient on 32 bits (replaced by off_t (and also size_t ?), translated via off64_t thanks to FILE_OFFSET_BITS=64 flag, as changed in earlier commit.
- Fix of a potential crash if segment_size is set to a too small value in config file (as it is used to determine the number of threads to be used if segment_above is reached).
- Test on segment_above > segment_size.
- Test of temp_dir presence if it is specified in config file (crash if not present).
- More return values. Specifically closed related TODO in cloudfsapi.c for segmented upload / download.
- Default parameters set with define (for avoiding discrepancies as found in commit
  e4cec697ab1dd730125a561dcafa041d6378ed92).
- Cache_timeout as unsigned int and replace atoll by strtoull.
- Compilation warnings cleanup using -Wall. Required reorganization of header files. Common includes between cloudfuse.c and cloudfsapi.c are merged in a cloudfuse.h.
- Common debug flag between the 2 .c files and cloudfuse.c' debugf is used in cloudfsapi.c.
- Issue 68 : Reduced sleep value from 8 to 1s. A HTTP404 leads to a 15s instead 120s wait time.
- Issue 24 : .utimens hook created. Underlying code is just a mock
- Added debug outputs, with timestamp and lock for threads syncing.
