### PR TITLE
Fix hubic_token script to handling % correctly

### DIFF
--- a/hubic_token
+++ b/hubic_token
@@ -250,7 +250,7 @@ error()
 
 urlenc()
 {
-    echo "$1" | sed -e 's|%|%21|g' \
+    echo "$1" | sed -e 's|%|%25|g' \
                   -e 's|!|%21|g' \
                   -e 's|#|%23|g' \
                   -e 's|\$|%24|g' \


### PR DESCRIPTION
It was escaped with the wrong ascii code :confused:

Fixes #72 